### PR TITLE
Add steady-state (SPGR) sequence optimization

### DIFF
--- a/+adpulses/+opt/arctanAD.m
+++ b/+adpulses/+opt/arctanAD.m
@@ -26,6 +26,7 @@ function [pulse_o, optInfos] = arctanAD(target, cube, pulse_i, varargin)
 %   keyword `lambda` is occupied in python, to be consistent, use η.
 % - gpuID (1,) which GPU to run the pulse design. If `-1`, use CPU.
 % - doRelax[T/f], allow spins to relax during simulation.
+% - doQuiet [T/f], suppress per-step optimizer log output.
 % - doClean [T/f], remove temporary files at finish.
 % - fName dflt 'arctanAD', name of the temporary files.
 
@@ -37,7 +38,8 @@ arg.b1Map = [];
 arg.err_meth = 'l2xy';
 [arg.pen_meth, arg.eta] = deal('l2', 4);
 arg.gpuID = 0;
-[arg.doRelax, arg.doClean] = deal(true, true);
+[arg.doRelax, arg.doQuiet] = deal(true, false);
+[arg.doClean] = deal(true);
 arg.fName = 'adpulses_opt_arctanAD';
 
 arg = attrParser(arg, varargin);
@@ -64,7 +66,8 @@ save(m2pName, '-v7', 'target', 'cube_st', 'pulse_st', 'arg')
 [p, ~, ~] = fileparts(mfilename('fullpath')); % .m/.py must be in the same path.
 pyfile = [p, '/arctanAD.py'];
 
-cmd = ['python ', pyfile, ' ', m2pName, ' ', p2mName, ' ', num2str(gpuID)];
+pyExec = char(pyenv().Executable);
+cmd = [pyExec, ' ', pyfile, ' ', m2pName, ' ', p2mName, ' ', num2str(gpuID)];
 Err = system(cmd);  % python call
 if Err, error('python call failed!!!'); end
 

--- a/+adpulses/+opt/arctanAD.py
+++ b/+adpulses/+opt/arctanAD.py
@@ -57,9 +57,12 @@ if __name__ == "__main__":
 
     fn_err, fn_pen = err_hash[err_meth], pen_hash[pen_meth]
 
+    doQuiet = dflt_arg('doQuiet', False, lambda k: bool(arg[k].item()))
+
     # %% pulse design
     kw = {k: arg[k] for k in ('b1Map_', 'niter', 'niter_gr', 'niter_rf',
                               'doRelax')}
+    kw.update({'doQuiet': doQuiet})
 
     pulse, optInfos = optimizers.arctanLBFGS(target, cube, pulse,
                                              fn_err, fn_pen, eta=eta, **kw)

--- a/+adpulses/+opt/arctanAD_spgr.m
+++ b/+adpulses/+opt/arctanAD_spgr.m
@@ -1,0 +1,97 @@
+function [pulse_o, optInfos] = arctanAD_spgr(target, cube, pulse_i, varargin)
+% Steady-state (SPGR) counterpart of `arctanAD`. Drives the steady-state
+% optimizer `adpulses.optimizers.arctanLBFGS_spgr` (via `arctanAD_spgr.py`),
+% optimizing against the steady-state magnetization of an
+% `[beta - alpha - readout] x N` SPGR sequence.
+%
+% This fn nastily relies on file save/read to pass variables to python calls.
+% Blame Matlab/Python poor interoperability.
+% The python part requires `scipy`, `mrphy` and `torch` (with CUDA).
+%INPUTS
+% - target (1,) structure:
+%   .d (*Nd, xyz)
+%   .weight (*Nd)
+% - cube mrphy.@SpinCube obj
+% - pulse_i mrphy.@Pulse obj
+%OPTIONAL
+% - b1Map (*Nd, nCoils)
+% - niter (1,), dflt 10, #iteration in autodiff
+% - niter_rf (1,), dflt 2, #iteration for updating rf
+% - niter_gr (1,), dflt 2, #iteration for updating gr
+% - err_meth str:
+%   'l2': least square excitation error metric accounting for all M_{x,y,z};
+%   'l2xy': ordinary transversal least square excitation error metric;
+%   'ml2xy': transversal magnitude least square excitation error metric;
+%   'l2z': longitudinal least square.
+% - pen_meth str:
+%   'null': no regularization.
+%   'l2': least square, RF power regularizer.
+% - eta (1,), Tikhonov coefficient for regularization, i.e., λ.
+%   keyword `lambda` is occupied in python, to be consistent, use η.
+% - gpuID (1,) which GPU to run the pulse design. If `-1`, use CPU.
+% - doRelax[T/f], allow spins to relax during simulation.
+% - doQuiet [T/f], suppress per-step optimizer log output.
+% - TR (1,) s, repetition time. Dflt 55e-3 if [].
+% - alpha (1,) deg, flip angle of tip-down pulse. Dflt 0 if [].
+% - doClean [T/f], remove temporary files at finish.
+% - fName dflt 'arctanAD_spgr', name of the temporary files.
+
+import attr.*
+
+% parse
+arg.b1Map = [];
+[arg.niter, arg.niter_gr, arg.niter_rf] = deal(8, 2, 2);
+arg.err_meth = 'l2xy';
+[arg.pen_meth, arg.eta] = deal('l2', 4);
+arg.gpuID = 0;
+[arg.doRelax, arg.doQuiet] = deal(true, false);
+[arg.TR, arg.alpha] = deal([], []);
+[arg.doClean] = deal(true);
+arg.fName = 'adpulses_opt_arctanAD_spgr';
+
+arg = attrParser(arg, varargin);
+disp(['err_meth: ', arg.err_meth])
+
+[arg.err_meth, arg.pen_meth] = deal(lower(arg.err_meth), lower(arg.pen_meth));
+assert(ismember(arg.err_meth, {'null', 'l2', 'l2xy', 'ml2xy', 'l2z'}))
+assert(ismember(arg.pen_meth, {'null', 'l2'}))
+
+[m2pName, p2mName] = deal([arg.fName, '_m2p.mat'], [arg.fName, '_p2m.mat']);
+gpuID = arg.gpuID;
+
+%% python call
+if size(target.d, 4) ~= 3  % -> (*Nd, xyz)
+  d = target.d;
+  target.d = cat(4, real(d), imag(d), sqrt(1-abs(d).^2));
+end
+
+[cube_st, pulse_st] = deal(cube.asstruct(), pulse_i.asstruct());
+
+% `'-v7'` for scipy.io compatibility
+save(m2pName, '-v7', 'target', 'cube_st', 'pulse_st', 'arg')
+
+[p, ~, ~] = fileparts(mfilename('fullpath')); % .m/.py must be in the same path.
+pyfile = [p, '/arctanAD_spgr.py'];
+
+pyExec = char(pyenv().Executable);
+cmd = [pyExec, ' ', pyfile, ' ', m2pName, ' ', p2mName, ' ', num2str(gpuID)];
+Err = system(cmd);  % python call
+if Err, error('python call failed!!!'); end
+
+%% back to matlab
+% $p2mName contains the following arguments:
+% - pulse_o
+% - optInfos
+
+mfile = matfile(p2mName);
+
+% may need some reshaping before assigning to mrphy.Pulse
+[pulse_st, arg_p2m] = deal(mfile.pulse_st, mfile.arg);
+optInfos = arg_p2m.optInfos;
+pulse_st.rf = pulse_st.rf(1,:,:) + 1i*pulse_st.rf(2,:,:);
+pulse_o = copy(pulse_i);
+[pulse_o.rf, pulse_o.gr] = deal(double(pulse_st.rf), double(pulse_st.gr));
+
+if arg.doClean, delete(m2pName, p2mName); end
+
+end

--- a/+adpulses/+opt/arctanAD_spgr.py
+++ b/+adpulses/+opt/arctanAD_spgr.py
@@ -1,0 +1,82 @@
+# arctanAD_spgr.py
+# Steady-state (SPGR) counterpart of arctanAD.py: drives
+# adpulses.optimizers.arctanLBFGS_spgr instead of arctanLBFGS.
+
+import numpy as np
+import torch
+from torch import tensor
+
+from adpulses import io, optimizers, metrics, penalties
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) <= 1:  # mode DEBUG
+        import os
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+    m2pName = ('m2p.mat' if len(sys.argv) <= 1 else sys.argv[1])
+    p2mName = ('p2m.mat' if len(sys.argv) <= 2 else sys.argv[2])
+    gpuID = ('0' if len(sys.argv) <= 3 else sys.argv[3])
+
+    # %% load
+    if gpuID == '-1':
+        device, dtype = torch.device('cpu'), torch.float32
+    else:
+        device, dtype = torch.device('cuda:'+gpuID), torch.float32
+
+    target, cube, pulse, arg = io.m2p(m2pName, device=device, dtype=dtype)
+
+    def dflt_arg(k, v, fn):
+        return (fn(k) if ((k in arg.keys()) and (arg[k].size > 0)) else v)
+
+    f_c2r_np = lambda x, a: np.stack((x.real, x.imag), axis=a)  # noqa:E731
+    f_t = (lambda x, device=device, dtype=dtype:
+           tensor(x[None, ...], device=device, dtype=dtype))  # noqa:E731
+
+    arg['doRelax'] = dflt_arg('doRelax', True, lambda k: bool(arg[k].item()))
+
+    b1Map = dflt_arg('b1Map', None, lambda k: f_t(f_c2r_np(arg[k], -2)))
+    b1Map_ = dflt_arg('b1Map_', None, lambda k: f_t(f_c2r_np(arg[k], -2)))
+    assert ((b1Map_ is None) or (b1Map is None))
+
+    arg['b1Map_'] = (b1Map_ if b1Map is None else cube.extract(b1Map))
+
+    arg['niter'] = dflt_arg('niter', 8, lambda k: arg[k].item())
+    arg['niter_gr'] = dflt_arg('niter_gr', 2, lambda k: arg[k].item())
+    arg['niter_rf'] = dflt_arg('niter_rf', 2, lambda k: arg[k].item())
+
+    eta = dflt_arg('eta', 4, lambda k: float(arg[k].item()))
+    print('eta: ', eta)
+
+    err_meth = dflt_arg('err_meth', 'l2xy', lambda k: arg[k].item())
+    pen_meth = dflt_arg('pen_meth', 'l2', lambda k: arg[k].item())
+
+    err_hash = {'null': metrics.err_null, 'l2': metrics.err_l2,
+                'l2xy': metrics.err_l2xy, 'ml2xy': metrics.err_ml2xy,
+                'l2z': metrics.err_l2z}
+    pen_hash = {'null': penalties.pen_null, 'l2': penalties.pen_l2}
+
+    fn_err, fn_pen = err_hash[err_meth], pen_hash[pen_meth]
+
+    doQuiet = dflt_arg('doQuiet', False, lambda k: bool(arg[k].item()))
+
+    # steady-state (SPGR) specific
+    TR = dflt_arg('TR', None, lambda k: float(arg[k].item()))
+    alpha = dflt_arg('alpha', None, lambda k: float(arg[k].item()))
+
+    # %% pulse design
+    kw = {k: arg[k] for k in ('b1Map_', 'niter', 'niter_gr', 'niter_rf',
+                              'doRelax')}
+    kw.update({'doQuiet': doQuiet})
+    # forward TR/alpha only when provided; else use arctanLBFGS_spgr defaults
+    if TR is not None:
+        kw['TR'] = TR
+    if alpha is not None:
+        kw['alpha'] = alpha
+
+    pulse, optInfos = optimizers.arctanLBFGS_spgr(target, cube, pulse,
+                                                  fn_err, fn_pen, eta=eta, **kw)
+
+    # %% saving
+    io.p2m(p2mName, pulse, {'optInfos': optInfos})

--- a/+adpulses/+utils/plotPulseComparison.m
+++ b/+adpulses/+utils/plotPulseComparison.m
@@ -1,0 +1,78 @@
+function plotPulseComparison(pIni, pAD, dt_us,labels)
+% PLOTPULSECOMPARISON  Compare initial and optimized mrphy.Pulse objects.
+%
+%   plotPulseComparison(pIni, pAD)
+%   plotPulseComparison(pIni, pAD, dt_us)
+%
+%   Plots RF amplitude, RF phase, and Gx/Gy/Gz for pIni (blue) and pAD
+%   (red) side-by-side in a 5-row figure.
+%
+%   Inputs:
+%     pIni   - mrphy.Pulse, initial pulse  (rf: [1,nT] complex, gr: [3,nT])
+%     pAD    - mrphy.Pulse, optimized pulse (same size as pIni)
+%     dt_us  - (optional) dwell time in microseconds for the time axis.
+%               If omitted, the x-axis is sample index.
+%     labels - (optional) array of label strings for the two pulses,
+%               If omitted, labels = ['Initial','Optimized']
+
+nT = size(pIni.rf, 2);
+
+if nargin < 4 || isempty(labels)
+    labels = ["Initial", "Optimized"];
+end
+
+if nargin < 3 || isempty(dt_us)
+    t = 1:nT;
+    xlabel_str = 'Sample index';
+else
+    t = (0:nT-1) * dt_us * 1e-3;
+    xlabel_str = 'Time (ms)';
+end
+
+rf_ini = pIni.rf(1,:);
+rf_ad  = pAD.rf(1,:);
+gr_ini = pIni.gr;   % [3, nT]
+gr_ad  = pAD.gr;
+
+amp_ini   = abs(rf_ini);
+amp_ad    = abs(rf_ad);
+phase_ini = angle(rf_ini) * 180/pi;
+phase_ad  = angle(rf_ad)  * 180/pi;
+
+chan_labels = {'Gx', 'Gy', 'Gz'};
+
+figure('Name','Pulse Comparison','NumberTitle','off', ...
+       'Units','normalized','Position',[0.05 0.05 0.6 0.88]);
+
+%% --- RF Amplitude ---
+subplot(5,1,1);
+plot(t, amp_ini, 'b-',  'DisplayName',labels(1));  hold on;
+plot(t, amp_ad,  'r--', 'DisplayName',labels(2));
+ylabel('|RF| (a.u.)');
+title('RF Amplitude');
+legend('Location','best');
+grid on; xlim([t(1) t(end)]);
+
+%% --- RF Phase ---
+subplot(5,1,2);
+plot(t, phase_ini, 'b-',  'DisplayName',labels(1));  hold on;
+plot(t, phase_ad,  'r--', 'DisplayName',labels(2));
+ylabel('Phase (deg)');
+title('RF Phase');
+legend('Location','best');
+grid on; xlim([t(1) t(end)]);
+
+%% --- Gradients ---
+for ch = 1:3
+    subplot(5,1,2+ch);
+    plot(t, gr_ini(ch,:), 'b-',  'DisplayName',labels(1));  hold on;
+    plot(t, gr_ad(ch,:),  'r--', 'DisplayName',labels(2));
+    ylabel('(a.u.)');
+    title(chan_labels{ch});
+    legend('Location','best');
+    grid on; xlim([t(1) t(end)]);
+end
+
+xlabel(xlabel_str);
+
+end

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@
 *.vscode/
 *.egg-info/
 
+examples_matlab/
++attr/
+build/
+dist/
+matlab_deps/

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ cite as:
 ```bib
 @article{luo2021joint,
   author={Luo, Tianrui and Noll, Douglas C. and Fessler, Jeffrey A. and Nielsen, Jon-Fredrik},
-  journal={IEEE Transactions on Medical Imaging}, 
-  title={Joint Design of RF and gradient waveforms via auto-differentiation for 3D tailored excitation in MRI}, 
+  journal={IEEE Transactions on Medical Imaging},
+  title={Joint Design of RF and gradient waveforms via auto-differentiation for 3D tailored excitation in MRI},
   year={2021},
   volume={},
   number={},
@@ -29,11 +29,23 @@ For the `interpT` feature, consider citing:
 }
 ```
 
-## System Requirements:
-- Ubuntu 18.04, 20.04
-- Python 3.6, 3.7, 3.8
+## Steady-state sequence optimization
 
-The implementation was not tested with other configurations.
+Besides regular tailored-excitation design, the pulse can be optimized against
+the steady-state magnetization of an SPGR
+sequence. Use `adpulses.optimizers.arctanLBFGS_spgr` (Python) or
+`adpulses.opt.arctanAD_spgr` (MATLAB) — the steady-state counterparts of
+`arctanLBFGS` / `adpulses.opt.arctanAD`. `demo/demo_ss.m` gives a worked
+comparison of a regular design against a steady-state design.
+
+This feature accompanies a technical note currently under review at
+*Magnetic Resonance in Medicine*; a citation will be added once available.
+
+## System Requirements:
+- Python `≥3.8`.
+
+Tested on Ubuntu 18.04 / 20.04; other operating systems are untested but not
+explicitly excluded.
 
 ## General comments
 
@@ -41,21 +53,34 @@ The implementation was not tested with other configurations.
 For the python part, in your command line, navigate to the repo's root directory, type:
 
 ```sh
-pip install .
+pip install -e .
 ```
 
-Demos are provided in `./demo`.
-
-This repo has included binary test data files for basic accessibility in certain regions.\
-Future binary data files will be added to: <https://drive.google.com/drive/folders/1EyKhA_d74OC4KADMuTd1kRTEMoVqWdIY>.
+Demos are provided in `./demo`. In particular, `demo/demo_ss.m` uses the
+included example dataset (`demo/IniVars.mat`) to compare a regular design
+against a steady-state design under steady-state Bloch simulation.
 
 ## Dependencies
 
-This work requries Python (`≥v3.5`), PyTorch (`≥v1.3`) with CUDA.
+This work requires Python (`≥v3.8`) and PyTorch (`≥v1.6`).
 
-- `MRphy`: Python, Github [link](https://github.com/tianrluo/MRphy.py) (`≥v0.1.8`).
-- `+mrphy`: Matlab, Github [link](https://github.com/tianrluo/MRphy.mat).
-- `+attr`: Matlab, Github [link](https://github.com/fmrilab/attr.mat).
+### Python
+`pip install -e .` (see above) installs all Python dependencies, including the
+steady-state-enabled MRphy.py (pinned in `setup.py`):
 
-Other Python dependencies include:\
-`scipy`, `numpy`, `PyTorch`.
+- `mrphy`: [tianrluo/MRphy.py](https://github.com/tianrluo/MRphy.py.git) (`≥v0.2.1`) — with steady-state (SPGR) Bloch simulation support (`mrphy.steady_state.spgr`).
+
+Other Python dependencies (`numpy`, `scipy`, `torch`) are installed automatically.
+
+### MATLAB
+`setup_AutoDiffPulses.m` bootstraps the MATLAB dependencies automatically: it
+clones the packages below into `./matlab_deps` (git-ignored) at the pinned
+commits, compiles the C Bloch simulator (`mex blochcim.c`), and adds them to the
+path. This requires `git` on the system `PATH`. To force a fresh checkout,
+delete `./matlab_deps` and re-run the script.
+
+- `+mrphy`: [tianrluo/MRphy.mat](https://github.com/tianrluo/MRphy.mat.git) — the MATLAB counterpart, extended with steady-state Bloch simulation support.
+- `+attr`: [fmrilab/attr.mat](https://github.com/fmrilab/attr.mat).
+
+MATLAB must also be configured (via `pyenv`) to use a Python environment that
+has the `mrphy` installation described above.

--- a/adpulses/optimizers.py
+++ b/adpulses/optimizers.py
@@ -162,3 +162,170 @@ def arctanLBFGS(
     optInfos = {'time_hist': time_hist, 'loss_hist': loss_hist,
                 'err_hist': err_hist, 'pen_hist': pen_hist}
     return pulse, optInfos
+
+
+def arctanLBFGS_spgr(
+    target: dict, cube: SpinCube, pulse: Pulse,
+    fn_err: Callable[[Tensor, Tensor, Optional[Tensor]], Tensor],
+    fn_pen: Callable[[Tensor], Tensor],
+    niter: int = 8, niter_gr: int = 2, niter_rf: int = 2,
+    eta: Number = 4.,
+    b1Map_: Optional[Tensor] = None, b1Map: Optional[Tensor] = None,
+    doQuiet: bool = False, doRelax: bool = True,
+    TR: float = 55e-3,
+    alpha: float = 0.,
+) -> Tuple[Pulse, dict]:
+    r"""Joint RF/GR optimization for steady-state (SPGR) sequences.
+
+    Steady-state counterpart of :func:`arctanLBFGS`. The loss is evaluated on
+    the steady-state magnetization of an outer-volume-suppression SPGR
+    sequence, ``[beta - alpha - readout] x N``, simulated by
+    ``mrphy.steady_state.spgr.spgr_ovs``.
+
+    Usage:
+        ``arctanLBFGS_spgr(target, cube, pulse, fn_err, fn_pen; eta=eta)``
+
+    Inputs:
+        - ``target``: dict, with fields:
+            ``d_``: `(1, nM, xy)`, desired excitation;
+            ``weight_``: `(1, nM)`.
+        - ``cube``: mrphy.mobjs.SpinCube.
+        - ``pulse``: mrphy.mobjs.Pulse.
+        - ``fn_err``: error metric function. See :mod:`~adpulses.metrics`.
+        - ``fn_pen``: penalty function. See :mod:`~adpulses.penalties`.
+    Optionals:
+        - ``niter``: int, number of iterations.
+        - ``niter_gr``: int, number of LBFGS iters for updating *gradients*.
+        - ``niter_rf``: int, number of LBFGS iters for updating *RF*.
+        - ``eta``: `(1,)`, penalization term weighting coefficient.
+        - ``b1Map_``: `(1, nM, xy,(nCoils))`, a.u., transmit sensitivity.
+        - ``doRelax``: [T/f], whether accounting relaxation effects in simu.
+        - ``TR``: float, repetition time (s). Defaults to 55e-3.
+        - ``alpha``: float, flip angle (deg) for the tip-down pulse.
+          Defaults to 0.
+    Outputs:
+        - ``pulse``: mrphy.mojbs.Pulse, optimized pulse.
+        - ``optInfos``: dict, optimization informations.
+    """
+    from mrphy.steady_state import spgr
+
+    rfmax, smax = pulse.rfmax, pulse.smax
+    eta *= pulse.dt*1e6/4  # normalize eta by dt
+    assert ((b1Map_ is None) or (b1Map is None))
+    b1Map_ = (b1Map_ if b1Map is None else cube.extract(b1Map))
+    b1Map_ = b1Map_[..., None] if len(b1Map_.shape) == 3 else b1Map_
+
+    # Set up: Interior mapping
+    tρ, θ = mrphy.utils.rf2tρθ(pulse.rf, rfmax)
+    tsl = mrphy.utils.s2ts(mrphy.utils.g2s(pulse.gr, pulse.dt), smax)
+
+    # enforce contiguousness of optimization variables, o.w. LBFGS may fail
+    tρ, θ, tsl = tρ.contiguous(), θ.contiguous(), tsl.contiguous()
+
+    opt_rf = optim.LBFGS([tρ, θ], lr=3., max_iter=10, history_size=30,
+                         tolerance_change=1e-4,
+                         line_search_fn='strong_wolfe')
+
+    opt_sl = optim.LBFGS([tsl], lr=3., max_iter=40, history_size=60,
+                         tolerance_change=1e-6,
+                         line_search_fn='strong_wolfe')
+
+    tρ.requires_grad = θ.requires_grad = tsl.requires_grad = True
+
+    # Set up: optimizer
+    length = 1+niter*(niter_gr+niter_rf)
+    time_hist = np.full((length,), np.nan)
+    loss_hist = np.full((length,), np.nan)
+    err_hist = np.full((length,), np.nan)
+    pen_hist = np.full((length,), np.nan)
+
+    Md_, w_ = target['d_'], target['weight_'].sqrt()  # (1, nM, xy), (1, nM)
+    nM = w_.numel()
+
+    def fn_loss(cube, pulse):
+        Mr_ = spgr.spgr_ovs(cube, pulse, b1Map_=b1Map_, doRelax=doRelax,
+                            TR=TR, alpha=alpha)
+        loss_err, loss_pen = fn_err(Mr_, Md_, w_=w_), fn_pen(pulse.rf)
+        return loss_err, loss_pen
+
+    log_col = ('\n#iter\t ‖ elapsed time\t ‖ error\t ‖ penalty\t ‖'
+               ' total loss\t ‖ avg loss')
+
+    def logger(i, t0, loss, err, pen):
+        e, p, lo = err.item(), pen.item(), loss.item()
+        msg = (f'{i}\t | {time()-t0:.3f}\t | {e:.3e}\t | {p:.3e}\t | '
+               f'{lo:.3e}\t | {lo/nM:.3e}')
+        print(msg)
+        return loss
+
+    loss_err, loss_pen = fn_loss(cube, pulse)
+    loss = loss_err + eta*loss_pen
+
+    logger(0, time(), loss, loss_err, loss_pen)
+    time_hist[0], loss_hist[0], err_hist[0], pen_hist[0] = (
+        0.0, loss.item(), loss_err.item(), loss_pen.item())
+
+    # Optimization
+    t0 = time()
+    for i in range(niter):
+
+        if not (i % 5):
+            print(log_col)
+
+        log_ind = 0
+
+        def closure():
+            opt_rf.zero_grad()
+            opt_sl.zero_grad()
+
+            pulse.rf = mrphy.utils.tρθ2rf(tρ, θ, rfmax)
+            pulse.gr = mrphy.utils.s2g(mrphy.utils.ts2s(tsl, smax), pulse.dt)
+
+            loss_err, loss_pen = fn_loss(cube, pulse)
+            loss = loss_err + eta*loss_pen
+            loss.backward()
+            return loss
+
+        print('rf-loop: ', niter_rf)
+        for _ in range(niter_rf):
+            opt_rf.step(closure)
+
+            loss_err, loss_pen = fn_loss(cube, pulse)
+            loss = loss_err + eta*loss_pen
+
+            if not doQuiet:
+                logger(i+1, t0, loss, loss_err, loss_pen)
+
+            ind = i*(niter_gr+niter_rf)+log_ind+1
+            time_hist[ind], loss_hist[ind], err_hist[ind], pen_hist[ind] = (
+                time()-t0, loss.item(), loss_err.item(), loss_pen.item())
+
+            log_ind += 1
+
+        print('gr-loop: ', niter_gr)
+        for _ in range(niter_gr):
+            opt_sl.step(closure)
+
+            loss_err, loss_pen = fn_loss(cube, pulse)
+            loss = loss_err + eta*loss_pen
+
+            if not doQuiet:
+                logger(i+1, t0, loss, loss_err, loss_pen)
+
+            ind = i*(niter_gr+niter_rf)+log_ind+1
+            time_hist[ind], loss_hist[ind], err_hist[ind], pen_hist[ind] = (
+                time()-t0, loss.item(), loss_err.item(), loss_pen.item())
+
+            log_ind += 1
+
+    print('\n== Results: ==')
+    print(log_col)
+    loss = loss_err + eta*loss_pen
+
+    logger(i+1, t0, loss, loss_err, loss_pen)
+
+    pulse.rf.detach_()
+    pulse.gr.detach_()
+    optInfos = {'time_hist': time_hist, 'loss_hist': loss_hist,
+                'err_hist': err_hist, 'pen_hist': pen_hist}
+    return pulse, optInfos

--- a/demo/demo_ss.m
+++ b/demo/demo_ss.m
@@ -1,0 +1,167 @@
+%function demo_ss()
+% Compares steady-state-aware pulse design (OV90_ss) with regular design (OV90).
+% Both pulses are evaluated under steady-state Bloch simulation and compared
+% against the steady-state target.  
+% Hypothesis: pAD_ss should be closer to target_ss than pAD.
+
+IniVar = matfile('./IniVars.mat');
+cube        = IniVar.cube;
+pIni        = IniVar.pIni_OV90;
+target_OV90 = IniVar.target_OV90;
+
+TR    = 60e-3;  % s
+alpha = 0;      % deg, tip-down flip angle
+
+% Derive IV (box) and OV masks from the existing OV90 target:
+%   IV: Mz target == 1  (0-deg, no excitation)
+%   OV: the rest of the object support
+msk     = logical(cube.mask);
+iv_mask = (target_OV90.d(:,:,:,3) == 1) & msk;
+ov_mask = msk & ~iv_mask;
+
+% Steady-state target: 0-deg IV, 90-deg OV
+[target_ss.d, target_ss.weight] = mrphy.steady_state.spgr.target_ovs( ...
+    cube, 0, 90, iv_mask, ov_mask, 'TR', TR, 'alpha', alpha);
+
+% --- Design pulses ---
+[pAD_ss, ~] = OV90_ss(cube, target_ss, pIni, TR, alpha);
+[pAD,    ~] = OV90(cube, target_OV90, pIni);
+
+%%
+% --- Evaluate both pulses under steady-state simulation ---
+M1_ss = mrphy.steady_state.spgr.spgr_ovs(cube, pAD,    'TR', TR, 'alpha', alpha, 'doEmbed', true);  % regular design
+M2_ss = mrphy.steady_state.spgr.spgr_ovs(cube, pAD_ss, 'TR', TR, 'alpha', alpha, 'doEmbed', true);  % ss design
+
+% --- Evaluate both pulses under regular bloch simulation ---
+M1 = cube.applypulse(pAD, 'doEmbed',true);  % regular design
+M2 = cube.applypulse(pAD_ss, 'doEmbed',true);  % ss design
+
+%%
+% --- Compare SS Simulation---
+plot_res(M1_ss,M2_ss,cube,target_ss,'z') %M2_ss is closer to target than M1_ss, specifically in IV
+
+% --- Compare regular Bloch Simulation ---
+plot_res(M1,M2,cube,target_OV90,'z') %M1 is closer to target than M2 for regular blochsim
+
+% --- compare the pulse waveforms --
+adpulses.utils.plotPulseComparison(pAD,pAD_ss,[],["Regular design","Steady-state design"])
+
+% =========================================================================
+function [pAD_ss, optInfo] = OV90_ss(cube, target_ss, pIni, TR, alpha)
+  [pAD_ss, optInfo] = adpulses.opt.arctanAD_spgr(target_ss, cube, pIni, ...
+      'err_meth', 'l2z', ...
+      'TR',       TR,    ...
+      'alpha',    alpha, ...
+      'doClean', false, 'gpuID', 0);
+end
+
+function [pAD, optInfo] = OV90(cube, target, pIni)
+  [pAD, optInfo] = adpulses.opt.arctanAD(target, cube, pIni, ...
+      'err_meth', 'l2z', ...
+      'doClean', false, 'gpuID', 0);
+end
+
+function plot_res(MT_1, MT_2, cube, target, xy_z)
+% inputs:
+%   MT_1: [nx,ny,nz,3]
+%   MT_2: [nx,ny,nz,3]
+  
+  if strcmpi(xy_z, 'xy')
+    % xy component and transversal MLS NRMSE
+    fn_res = @(MT)MT(:,:,:,1) + 1i*MT(:,:,:,2);
+    fn_tile = @(P)abs(tile3dto2d(P));
+    cl_res = [0, 1];
+  elseif strcmpi(xy_z, 'z')
+    % z component and longitudinal LS NRMSE
+    fn_res = @(MT)MT(:,:,:,3);
+    fn_tile = @(P)tile3dto2d(P);
+    cl_res = [-1, 1];
+  else, error('Unknown xy_z type');
+  end
+  
+  d = fn_res(target.d);
+  nan_mask = ~logical(cube.mask);
+  d(nan_mask) = 0;
+ 
+  [MT_1, MT_2] = deal(fn_res(MT_1), fn_res(MT_2));
+
+  MT_1(nan_mask) = 0;
+  MT_2(nan_mask) = 0;
+
+  % reshapes
+  [d, MT_1, MT_2] = deal(fn_tile(d), fn_tile(MT_1), fn_tile(MT_2));
+  
+  % NRMSE
+  in_mask = ~nan_mask;
+  nrmse = @(m) norm(m(in_mask) - d(in_mask)) / norm(d(in_mask));
+  e1 = nrmse(MT_1);
+  e2 = nrmse(MT_2);
+
+  figure
+  subplot(131);
+  imagesc(d); colorbar;
+  caxis(cl_res); axis('equal'); pbaspect([1,1,1]); title('target');
+  
+  subplot(132);
+  imagesc(MT_1); colorbar;
+  caxis(cl_res); axis('equal'); pbaspect([1,1,1]); title(sprintf('Regular design\nNRMSE=%.3f',e1));
+  
+  subplot(133);
+  imagesc(MT_2); colorbar;
+  caxis(cl_res); axis('equal'); pbaspect([1,1,1]); title(sprintf('Steady-state design\nNRMSE=%.3f',e2));
+end
+
+% =========================================================================
+function P = tile3dto2d(P)
+  [nx, ny, nz] = size(P);
+  nz_rt = sqrt(nz);
+  [nc, nr] = deal(ceil(nz_rt), floor(nz_rt));
+  P = cat(3, P, zeros([nx, ny, nr*nc-nz]));
+  P = reshape(P, nx, ny*nc, []);
+  P = reshape(permute(P, [2, 1, 3]), ny*nc, nx*nr).';
+end
+
+
+% % =========================================================================
+% function compare_ss(M1, M2, target_ss, cube)
+% % Show |Mxy| for target_ss, pAD (regular), and pAD_ss (ss-design), and
+% % report NRMSE for each.
+% 
+%   fn_res  = @(MT) MT(:,:,:,3); %Mz  %@(MT) MT(:,:,:,1) + 1i*MT(:,:,:,2);   % Mxy
+%   fn_tile = @(P)  abs(tile3dto2d(P));
+%   cl_res  = [0, 1];
+% 
+%   d  = fn_res(target_ss.d);
+%   nan_mask = ~logical(cube.mask);
+%   d(nan_mask) = 0;
+% 
+%   r1 = fn_res(M1);  r1(nan_mask) = 0;
+%   r2 = fn_res(M2);  r2(nan_mask) = 0;
+% 
+%   in_mask = ~nan_mask;
+%   nrmse = @(m) norm(m(in_mask) - d(in_mask)) / norm(d(in_mask));
+%   e1 = nrmse(r1);
+%   e2 = nrmse(r2);
+%   fprintf('NRMSE  pAD (regular): %.4f\n', e1);
+%   fprintf('NRMSE  pAD_ss (ss)  : %.4f\n', e2);
+% 
+%   figure
+%   subplot(131)
+%   imagesc(fn_tile(d));  colorbar; clim(cl_res); axis equal; pbaspect([1,1,1]);
+%   %title('target\_ss  |Mxy|');
+%   title('target\_ss  |Mz|');
+% 
+%   subplot(132)
+%   imagesc(fn_tile(r1)); colorbar; clim(cl_res); axis equal; pbaspect([1,1,1]);
+%   title(sprintf('pAD (regular)\nNRMSE=%.3f', e1));
+% 
+%   subplot(133)
+%   imagesc(fn_tile(r2)); colorbar; clim(cl_res); axis equal; pbaspect([1,1,1]);
+%   title(sprintf('pAD\\_ss (ss-design)\nNRMSE=%.3f', e2));
+% 
+%   %sgtitle('Steady-state |Mxy|: OV90 vs OV90\_ss');
+%   sgtitle('Steady-state |Mz|: OV90 vs OV90\_ss');
+% end
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,23 @@
 from setuptools import setup, find_packages
-import ctypes
 
-
-def cuda_is_available():
-    libnames = ('libcuda.so', 'libcuda.dylib', 'cuda.dll')
-    for name in libnames:
-        try:
-            ctypes.CDLL(name)
-        except OSError:
-            continue
-        else:
-            return True
-    else:
-        return False
-    return False
-
-
-REQUIRED_PACKAGES = ['torch>=1.6', 'numpy', 'scipy']
-
-# REQUIRED_PACKAGES = ['torch>=1.6', 'numpy', 'cupy>=7.0.0', 'mrphy>=0.1.5']
-# if not cuda_is_available():
-#     REQUIRED_PACKAGES.remove('cupy>=7.0.0')
+REQUIRED_PACKAGES = [
+    'torch>=1.6',
+    'numpy',
+    'scipy',
+    # MRphy.py with steady-state (SPGR) Bloch simulation support
+    # (`mrphy.steady_state.spgr`), first released in v0.2.1.
+    'mrphy @ git+https://github.com/tianrluo/MRphy.py.git@v0.2.1',
+]
 
 with open("README.md", "r") as h:
     long_description = h.read()
 
 setup(
     name="adpulses",
-    version="0.2.2",
-    author="Tianrui Luo",
-    author_email="tianrluo@umich.edu",
-    description="A Pytorch based tool for MR pulse design",
+    version="0.3.0",
+    author="Tianrui Luo, Yongli He",
+    author_email="tianrluo@umich.edu, yonglihe@umich.edu",
+    description="A Pytorch based tool for MR pulse design, with support for steady-state sequence optimization",
     license='MIT',
     long_description=long_description,
     long_description_content_type="text/x-rst",
@@ -41,5 +28,5 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.5',
+    python_requires='>=3.8',
 )

--- a/setup_AutoDiffPulses.m
+++ b/setup_AutoDiffPulses.m
@@ -5,6 +5,23 @@ if ~exist('doSavePath','var'), doSavePath = false; end
 theDir = fileparts(mfilename('fullpath'));
 prevDir = cd(theDir);
 
+%% MATLAB dependencies (auto-bootstrap)
+% Clone the steady-state-enabled MATLAB packages into ./matlab_deps at pinned
+% versions, then compile the C Bloch simulator.
+% This folder is git-ignored; delete it to force a fresh checkout.
+depsDir = fullfile(theDir, 'matlab_deps');
+if ~exist(depsDir, 'dir'), mkdir(depsDir); end
+
+setupDep(fullfile(depsDir, '+mrphy'), ...
+         'https://github.com/tianrluo/MRphy.mat.git', ...
+         'v0.2.1');
+setupDep(fullfile(depsDir, '+attr'), ...
+         'https://github.com/fmrilab/attr.mat.git', '');
+
+compileBlochcim(fullfile(depsDir, '+mrphy', '+sims'));
+
+addpath(depsDir);  % parent dir of the +mrphy / +attr packages
+
 %% generate path
 % don't use pwd in genpath, as names in dName_rm_c can appear in it.
 dName_s = genpath('.'); % _s: string, not string type though
@@ -14,8 +31,10 @@ dName_c = strsplit(dName_s, pathsep)'; % _c: cell
 dName_c(end) = []; % dName_s ends w/ pathsep, trailing dName_c an empty {}, rm.
 
 % customize dName_rm_c for different usages
+% 'matlab_deps' holds package folders (+mrphy, +attr); only their parent dir
+% belongs on the path, which is added explicitly above.
 dName_rm_c = {'demo', 'private', '.git', 'test', 'tests', 'arch', 'back', ...
-              'adpulses'};
+              'adpulses', 'matlab_deps'};
 
 fn_mtchd = @(x,y)~isempty(strfind(x,[y,filesep])); %#ok<STREMP>
 for iName = 1:numel(dName_rm_c)
@@ -35,4 +54,50 @@ if doSavePath, savepath; end
 disp('Make sure you have also setup the python codes, checkout `setup.py`.')
 %% head back
 cd(prevDir);
+end
+
+% =========================================================================
+function setupDep(targetDir, url, commit)
+% Clone `url` into `targetDir` (named so MATLAB sees it as the right package)
+% and, if given, checkout the pinned `commit`. No-op if already present.
+  if exist(targetDir, 'dir')
+    fprintf('[setup] dependency present, skipping clone: %s\n', targetDir);
+    return;
+  end
+  fprintf('[setup] cloning %s -> %s\n', url, targetDir);
+  if system(sprintf('git clone "%s" "%s"', url, targetDir)) ~= 0
+    error(['git clone failed for %s.\n', ...
+           'Ensure `git` is installed and the URL is reachable, or clone ', ...
+           'it manually to %s.'], url, targetDir);
+  end
+  if ~isempty(commit)
+    if system(sprintf('git -C "%s" checkout --quiet %s', targetDir, commit)) ~= 0
+      warning('Could not checkout pinned commit %s in %s.', commit, targetDir);
+    end
+  end
+end
+
+% =========================================================================
+function compileBlochcim(simsDir)
+% Compile the C Bloch simulator (blochcim.c) with mex, unless already built.
+  src = fullfile(simsDir, 'blochcim.c');
+  if ~exist(src, 'file')
+    warning('blochcim.c not found at %s; skipping mex compile.', src);
+    return;
+  end
+  if ~isempty(dir(fullfile(simsDir, ['blochcim.', mexext])))
+    fprintf('[setup] blochcim already compiled, skipping.\n');
+    return;
+  end
+  fprintf('[setup] compiling %s\n', src);
+  prev = cd(simsDir);
+  try
+    mex blochcim.c
+  catch ME
+    msg = sprintf(['mex compile failed: %s\n', ...
+                   'Compile manually with `mex blochcim.c` in %s.'], ...
+                  ME.message, simsDir);
+    warning('%s', msg);
+  end
+  cd(prev);
 end


### PR DESCRIPTION
Adds support for designing RF/gradient waveforms against the steady-state magnetization of an SPGR sequence. The steady-state path is implemented independently of arctanLBFGS, so the existing API and behavior are unchanged.

### What's added
Major:
- `adpulses.optimizers.arctanLBFGS_spgr` — a standalone steady-state optimizer. It mirrors arctanLBFGS but evaluates the loss on the SPGR steady-state magnetization via mrphy.steady_state.spgr.spgr_ovs, and takes TR / alpha parameters.
- `+adpulses/+opt/arctanAD_spgr.m + arctanAD_spgr.py` — parallel MATLAB↔Python entry points for the steady-state optimizer (mirroring arctanAD.m/arctanAD.py).
- `demo/demo_ss.m` — an example comparing a regular design against a steady-state design under steady-state Bloch simulation.

Minor:
- Bumped up version 0.2.2 -> 0.3.0; updated the dependencies.
- Updated README to reflect the changes.

(Message drafted by AI)