### PR TITLE
fix crash when no b1Map is provided to arctanLBFGS

### DIFF
--- a/adpulses/optimizers.py
+++ b/adpulses/optimizers.py
@@ -45,7 +45,6 @@ def arctanLBFGS(
     eta *= pulse.dt*1e6/4  # normalize eta by dt
     assert ((b1Map_ is None) or (b1Map is None))
     b1Map_ = (b1Map_ if b1Map is None else cube.extract(b1Map))
-    b1Map_ = b1Map_[..., None] if len(b1Map_.shape) == 3 else b1Map_
     # nc = (1 if b1Map_ is None else b1Map_.shape[3])
     # eta /= nc
 
@@ -213,7 +212,6 @@ def arctanLBFGS_spgr(
     eta *= pulse.dt*1e6/4  # normalize eta by dt
     assert ((b1Map_ is None) or (b1Map is None))
     b1Map_ = (b1Map_ if b1Map is None else cube.extract(b1Map))
-    b1Map_ = b1Map_[..., None] if len(b1Map_.shape) == 3 else b1Map_
 
     # Set up: Interior mapping
     tρ, θ = mrphy.utils.rf2tρθ(pulse.rf, rfmax)


### PR DESCRIPTION
when no b1Map is passed, `len(b1Map_.shape)` raises `'NoneType' object has no attribute 'shape'` error.

The pre-adding a singleton coil axis line is redundant anyway since mrphy's rfgr2beff handles 3D b1Map_ internally and accepts b1Map=None